### PR TITLE
Added parameter to set email recipient, defaults to joomla mail from 

### DIFF
--- a/emailconfigverifier.php
+++ b/emailconfigverifier.php
@@ -22,7 +22,7 @@ if(!defined('DS')){
  * @package	Test Email
  * @subpackage	Plugin
  * @author 	puneetsinghal@readybytes.in
- * 
+ *
  */
 class  plgSystemEmailconfigverifier extends JPlugin
 {
@@ -40,12 +40,12 @@ class  plgSystemEmailconfigverifier extends JPlugin
 	{
 		parent::__construct($subject, $config);
 		$this->_app = JFactory::getApplication();
-		
+
 		if(JVERSION < 3.0){
 			$this->loadLanguage();
 		}
 	}
-	
+
 	function onAfterRender()
 	{
 		$option = JRequest::getVar('option');
@@ -54,7 +54,7 @@ class  plgSystemEmailconfigverifier extends JPlugin
 		}
 		// Only render for HTML output
 		if (JFactory::getDocument()->getType() !== 'html' ) { return; }
-		
+
 		if(JVERSION < 3.0){
 			$html = $this->_getJ25Html();
 		}
@@ -64,40 +64,42 @@ class  plgSystemEmailconfigverifier extends JPlugin
 		$body = JResponse::getBody();
 		$body = str_replace('</body>', $html.'</body>', $body);
 		JResponse::setBody($body);
-		
+
 		return true;
 	}
-	
+
 	function onAfterRoute()
 	{
 		$input = $this->_app->input;
 		$option = $input->get('option', false);
 		$is_testemail = $input->get('plg_testemail', false);
-		
+
 		if($option != 'com_config' || !$is_testemail){
 			return true;
 		}
-		
+
 		$from 	= $input->get('from_email', false, 'string');
 		$sender = $input->get('from_name', false);
 		$date 	= JDate::getInstance()->toSql();
-		
+
 		$subject = JText::_('PLG_SYSTEM_TESTEMAIL_EMAIL_SUBJECT');
 		$body 	 = JText::sprintf('PLG_SYSTEM_TESTEMAIL_EMAIL_BODY', $date);
 		$result	 = array();
 		$message = JText::_('PLG_SYSTEM_TESTEMAIL_MESSAGE_SUCCESS');
 		$state	 = 'message';
-		
+
 		$mailer = self::createMailer();
-		
-		if ($mailer->sendMail($from, $sender, $from, $subject, $body) !== true)
+
+		$recipient = $this->params->get('mailto', $from);
+
+		if ($mailer->sendMail($from, $sender, $recipient, $subject, $body) !== true)
 		{
 			$this->_error();
 		}
-		
+
 		$this->_success();
 	}
-	
+
 	protected static function createMailer()
 	{
 		$input = JFactory::getApplication()->input;
@@ -136,17 +138,17 @@ class  plgSystemEmailconfigverifier extends JPlugin
 
 		return $mail;
 	}
-	
+
 	protected function _error()
 	{
 		$result['status'] = 'error';
 		$result['message']= JText::_('PLG_SYSTEM_TESTEMAIL_MESSAGE_ERROR');
 		$result = json_encode($result);
-		
+
 		echo $result;
 		exit();
 	}
-	
+
 	protected function _success()
 	{
 		$result['status'] = 'success';
@@ -156,12 +158,12 @@ class  plgSystemEmailconfigverifier extends JPlugin
 		echo $result;
 		exit();
 	}
-	
+
 	private function _getJ25Html()
 	{
 		ob_start();
 		?>
-		
+
 		<style type="text/css">
 			.btn {
 			  display: inline-block;
@@ -182,12 +184,12 @@ class  plgSystemEmailconfigverifier extends JPlugin
 			       -o-user-select: none;
 			          user-select: none;
 			}
-			
+
 			.pull-right{
 				float: right;
 			}
 		</style>
-		
+
 		<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script>
 		<script type="text/javascript">
 			(function($){
@@ -201,19 +203,19 @@ class  plgSystemEmailconfigverifier extends JPlugin
 					html = html + "<a href=\"http:\/\/www.jpayplans.com\" target=\"_blank\">Ready Bytes</a>"
 					html = html + "</span>";
 					html = html + "</span>";
-					
+
 					$("#jform_mailer-lbl").parent().append(html);
 				});
 			})(jQuery);
 		</script>
-		
-		<?php 
+
+		<?php
 		$html = ob_get_contents();
 		ob_end_clean();
 		$html .= $this->_getTestEmailScript();
 		return $html;
 	}
-	
+
 	private function _getJ30Html()
 	{
 		ob_start();
@@ -230,20 +232,20 @@ class  plgSystemEmailconfigverifier extends JPlugin
 						html = html + "<a href=\"http:\/\/www.jpayplans.com\" target=\"_blank\">Ready Bytes</a>"
 						html = html + "</span>";
 						html = html + "</span>";
-						
+
 					$("#jform_mailer-lbl").closest('fieldset').find('legend').append(html);
 					$("#content").prepend("<div id=\"jxi_email_msg\">&nbsp;</div>");
 				});
 			})(jQuery);
 		</script>
-		
-		<?php 
+
+		<?php
 		$html = ob_get_contents();
 		ob_end_clean();
 		$html .= $this->_getTestEmailScript();
 		return $html;
 	}
-	
+
 	private function _getTestEmailScript()
 	{
 		$root = JURI::root();
@@ -262,7 +264,7 @@ class  plgSystemEmailconfigverifier extends JPlugin
 						var url = "<?php echo $root;?>";
 						url = url + 'administrator/index.php?option=com_config&';
 						url = url + 'plg_testemail=1';
-						
+
 						var from_email	= $("#jform_mailfrom").val();
 						var mailer		= $('#jform_mailer :selected').val();
 						var from_name	= $('#jform_fromname').val();
@@ -272,8 +274,8 @@ class  plgSystemEmailconfigverifier extends JPlugin
 						var smtp_user	= $('#jform_smtpuser').val();
 						var smtp_pass	= $('#jform_smtppass').val();
 						var smtp_host	= $('#jform_smtphost').val();
-						
-						$.post(url, 
+
+						$.post(url,
 								{
 									from_email 	: from_email,
 									mailer		: mailer,
@@ -293,30 +295,30 @@ class  plgSystemEmailconfigverifier extends JPlugin
 							if(record.status == 'success'){
 								$('#jxi_email_msg').removeClass("alert alert-error");
 								$('#jxi_email_msg').addClass("alert alert-success");
-								var message = record.message; 
+								var message = record.message;
 								$('#jxi_email_msg').html(message);
 							}
 
 							if(record.status == 'error'){
 								$('#jxi_email_msg').removeClass("alert alert-success");
 								$('#jxi_email_msg').addClass("alert alert-error");
-								var message = record.message; 
+								var message = record.message;
 								$('#jxi_email_msg').html(message);
 							}
 
 							alert(message);
-							
+
 						});
 					});
 				});
 			})(jQuery);
 		</script>
-		
-		<?php 
+
+		<?php
 		$html = ob_get_contents();
 		ob_end_clean();
 		return $html;
 	}
-	
+
 }
 

--- a/emailconfigverifier.xml
+++ b/emailconfigverifier.xml
@@ -9,10 +9,10 @@
     <authorUrl>http://www.jpayplans.com</authorUrl>
     <copyright>2009-13 Ready Bytes Software Labs Pvt. Ltd.</copyright>
     <license>GNU General Public License v2</license>
-    <description>Test and verify your email configuration settings. Follow these steps to use this plugin :- &lt;br /&gt; 
-    			1) Go to Global Configuration.&lt;br /&gt; 
-    			2) Now, select Server tab. Here you will get  &lt;strong&gt; Test Email &lt;/strong&gt; button.  &lt;br /&gt; 
-    			3) Set email configuration and click on Test Email button. &lt;br /&gt; 
+    <description>Test and verify your email configuration settings. Follow these steps to use this plugin :- &lt;br /&gt;
+    			1) Go to Global Configuration.&lt;br /&gt;
+    			2) Now, select Server tab. Here you will get  &lt;strong&gt; Test Email &lt;/strong&gt; button.  &lt;br /&gt;
+    			3) Set email configuration and click on Test Email button. &lt;br /&gt;
     			4) IMP: You do not need to save global configuration again and again. Just set the values and click on button. It will test your settings with-in few seconds.&lt;br /&gt;
 	</description>
 	<files>
@@ -23,7 +23,14 @@
 		<language tag="en-GB">languages/en-GB.plg_system_emailconfigverifier.ini</language>
 		<language tag="en-GB">languages/en-GB.plg_system_emailconfigverifier.sys.ini</language>
 	</languages>
-	
+
 	<config>
+        <fields name="params">
+            <fieldset name="settings" label="PLG_SYSTEM_TESTEMAIL_XML_FIELDSET_SETTINGS">
+                <field name="mailto" type="text"
+                       label="PLG_SYSTEM_TESTEMAIL_XML_MAILTO_LABEL"
+                       description="PLG_SYSTEM_TESTEMAIL_XML_MAILTO_DESC"/>
+            </fieldset>
+        </fields>
 	</config>
 </extension>

--- a/languages/en-GB.plg_system_emailconfigverifier.ini
+++ b/languages/en-GB.plg_system_emailconfigverifier.ini
@@ -2,3 +2,7 @@ PLG_SYSTEM_TESTEMAIL_EMAIL_SUBJECT="Congratulations your emailing is working per
 PLG_SYSTEM_TESTEMAIL_EMAIL_BODY="Hip-hip hurrrayyyyy. Current Time is: %s"
 PLG_SYSTEM_TESTEMAIL_MESSAGE_SUCCESS="Email send successfully. IMPORTANT:- Save your current email settings."
 PLG_SYSTEM_TESTEMAIL_MESSAGE_ERROR="Email sending failed. Check your email settings and try again."
+
+PLG_SYSTEM_TESTEMAIL_XML_FIELDSET_SETTINGS="Settings"
+PLG_SYSTEM_TESTEMAIL_XML_MAILTO_LABEL="Mailto"
+PLG_SYSTEM_TESTEMAIL_XML_MAILTO_DESC="Select email to send test email to. Default to joomla From email"


### PR DESCRIPTION
Nice little utility plugin, but sometimes, you don't have access to the email set as joomla mail from (e.g. debugging a client install), so i added the possibility to set in the plugins parameters.
